### PR TITLE
#37: Bastion builder is now bound to Object first.

### DIFF
--- a/src/main/java/rocks/bastion/Bastion.java
+++ b/src/main/java/rocks/bastion/Bastion.java
@@ -162,7 +162,7 @@ public final class Bastion {
      * @param request The HTTP request that Bastion will execute for this test.
      * @return A fluent-builder object which will let you bind a model type, add assertions, add callbacks and execute the test.
      */
-    public static BastionBuilder<String> request(String message, HttpRequest request) {
+    public static BastionBuilder<Object> request(String message, HttpRequest request) {
         return BastionFactory.getDefaultBastionFactory().getBastion(message, request);
     }
 

--- a/src/main/java/rocks/bastion/core/BastionFactory.java
+++ b/src/main/java/rocks/bastion/core/BastionFactory.java
@@ -45,7 +45,7 @@ public abstract class BastionFactory {
 
     /**
      * Construct and initialise a new instance of the {@link BastionBuilderImpl} builder. By default, the returned builder
-     * will bind the response to a {@linkplain String} model. Also, the returned builder will use the specified
+     * will bind the response to a plain {@linkplain Object} model. Also, the returned builder will use the specified
      * {@code message} (for informational purposes) and {@code request}.
      *
      * @param message A non-{@literal null} String which describes the request/test that Bastion will be performing.
@@ -55,8 +55,8 @@ public abstract class BastionFactory {
      * @return A fully configured instance of the {@link BastionBuilderImpl} fluent builder which can be used directly by
      * the user to construct Bastion tests.
      */
-    public BastionBuilder<String> getBastion(String message, HttpRequest request) {
-        BastionBuilderImpl<String> bastion = new BastionBuilderImpl<>(message, request);
+    public BastionBuilder<Object> getBastion(String message, HttpRequest request) {
+        BastionBuilderImpl<Object> bastion = new BastionBuilderImpl<>(message, request);
         bastion.setSuppressAssertions(suppressAssertions);
         prepareBastion(bastion);
         return bastion;

--- a/src/test/java/rocks/bastion/support/DefaultBindingTest.java
+++ b/src/test/java/rocks/bastion/support/DefaultBindingTest.java
@@ -1,0 +1,22 @@
+package rocks.bastion.support;
+
+import org.junit.Test;
+import rocks.bastion.Bastion;
+import rocks.bastion.support.embedded.TestWithEmbeddedServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @see <a href="https://github.com/KPull/Bastion/issues/37">Issue #37</a>
+ */
+public class DefaultBindingTest extends TestWithEmbeddedServer {
+
+    @Test
+    public void testDefaultBinding() {
+        Bastion.request("Create Sushi Request", new CreateSushiRequest())
+                .withAssertions((statusCode, response, model) -> {
+                    assertThat(statusCode).isEqualTo(201);
+                }).call();
+    }
+
+}


### PR DESCRIPTION
Bugfix for the binding problem. No change to the implementation needed to be done. The problem was that the `Bastion.request()` method was returning `Bastion<String>` instead of `Bastion<Object>`. The decoded model was not necessarily bound to a `String` (which was causing the exception).

The associated test recreates the scenario which was throwing an exception.